### PR TITLE
Replace rust-crypto with sha2 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doc = false
 
 [dependencies]
 reqwest = "0.10.0"
-rust-crypto = "0.2"
+sha2 = "0.8"
 tempfile = "3.1"
 structopt = "0.3"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,7 @@ glob = "0.3"
 
 [dev-dependencies]
 httpmock = "0.3"
+
+# TODO: Remove when https://github.com/alexliesenfeld/httpmock/pull/4 is merged
+[patch.crates-io.httpmock]
+git = "https://github.com/korrat/httpmock"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -447,8 +447,9 @@ mod tests {
                 .to_str()
                 .unwrap(),
             format!(
-                "{}/{}.{}",
+                "{}{}{}.{}",
                 cache_dir.path().to_str().unwrap(),
+                std::path::MAIN_SEPARATOR,
                 "b5696dbf866311125e26a62bef0125854dd40f010a70be9cfd23634c997c1874",
                 "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"
             )
@@ -459,8 +460,9 @@ mod tests {
                 .to_str()
                 .unwrap(),
             format!(
-                "{}/{}",
+                "{}{}{}",
                 cache_dir.path().to_str().unwrap(),
+                std::path::MAIN_SEPARATOR,
                 "b5696dbf866311125e26a62bef0125854dd40f010a70be9cfd23634c997c1874",
             )
         );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,8 @@
-use crypto::digest::Digest;
-use crypto::sha2::Sha256;
+use sha2::{Digest, Sha256};
 use std::time::SystemTime;
 
 pub(crate) fn hash_str(s: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.input_str(s);
-    hasher.result_str()
+    format!("{:x}", Sha256::digest(s.as_bytes()))
 }
 
 pub(crate) fn now() -> f64 {


### PR DESCRIPTION
The RustSec security advisory database lists rust-crypto as
unmaintained. As such it is recommended that the crate is replaced with
a maintained alternative. This patch replaces the rust-crypto crate with
the sha2 crate and updates the affected hashing logic.

The patch also contains a change to a test that fails on windows.