### PR TITLE
Remove patch for httpmock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,3 @@ glob = "0.3"
 
 [dev-dependencies]
 httpmock = "0.3"
-
-# TODO: Remove when https://github.com/alexliesenfeld/httpmock/pull/4 is merged
-[patch.crates-io.httpmock]
-git = "https://github.com/korrat/httpmock"


### PR DESCRIPTION
`httpmock` version 0.3.5 has just been released, fixing the imports from the `assert-json-diff` crate. This means it's no longer necessary to patch the dependency.