### PR TITLE
Make more robust and add an offline mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
     - master
+  schedule:
+    - cron: '0 10 * * *' # run at 10 AM UTC
 
 jobs:
   build:
@@ -14,35 +16,67 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
-    - name: Install Rust Stable
+    - name: Install rust stable
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         components: rustfmt, clippy
         override: true
 
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose
+    - name: Fix ~/.cargo directory permissions
+      run: |
+        # Need to chown ~/.cargo or else the "Cache cargo registry" step will fail.
+        # See https://github.com/actions/cache/issues/133.
+        sudo chown -R $(whoami):$(id -ng) ~/.cargo/
 
-    - name: Lin with RustFmt
+    - name: Set build variables
+      run: |
+        # We use these variables as part of the cache keys.
+        echo "::set-env name=RUST_VERSION::$(rustc --version)"
+        echo "::set-env name=CARGO_VERSION::$(cargo --version)"
+
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: cargo registry ${{ github.job }} ${{ runner.os }} ${{ env.RUST_VERSION }} ${{ env.CARGO_VERSION }} ${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: |
+          cargo registry ${{ github.job }} ${{ runner.os }} ${{ env.RUST_VERSION }} ${{ env.CARGO_VERSION }}
+
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        path: target
+        key: cargo build ${{ github.job }} ${{ runner.os }} ${{ env.RUST_VERSION }} ${{ env.CARGO_VERSION }} ${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: |
+          cargo build ${{ github.job }} ${{ runner.os }} ${{ env.RUST_VERSION }} ${{ env.CARGO_VERSION }}
+
+    - name: Lint with rustfmt
+      if: always()
       uses: actions-rs/cargo@v1
       with:
         command: fmt
         args: -- --check
 
-    - name: Lint with Clippy
+    - name: Lint with clippy
+      if: always()
       uses: actions-rs/cargo@v1
       with:
         command: clippy
         args: --all-targets --all-features -- -D warnings
 
-    - name: Run Tests
+    - name: Run unit tests
+      if: always()
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose
+        args: --lib
+
+    - name: Run doc tests
+      if: always()
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached-path"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["epwalsh <epwalsh10@gmail.com>"]
 edition = "2018"
 keywords = ["http", "caching"]
@@ -21,6 +21,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+file-lock = "1.1"
 reqwest = "0.10.0"
 sha2 = "0.8"
 tempfile = "3.1"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,5 @@
 use failure::ResultExt;
+use file_lock::FileLock;
 use glob::glob;
 use log::{debug, error, info, warn};
 use rand::distributions::{Distribution, Uniform};
@@ -9,8 +10,8 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tempfile::NamedTempFile;
-use tokio::fs::{self, File, OpenOptions};
-use tokio::io::{self, AsyncWriteExt};
+use tokio::fs::{self, OpenOptions};
+use tokio::io::AsyncWriteExt;
 use tokio::time::{self, delay_for};
 
 use crate::utils::hash_str;
@@ -42,6 +43,7 @@ struct Config {
     max_retries: u32,
     max_backoff: u32,
     freshness_lifetime: Option<u64>,
+    offline: bool,
 }
 
 impl CacheBuilder {
@@ -54,6 +56,7 @@ impl CacheBuilder {
                 max_retries: 3,
                 max_backoff: 5000,
                 freshness_lifetime: None,
+                offline: false,
             },
         }
     }
@@ -105,6 +108,15 @@ impl CacheBuilder {
         self.config.freshness_lifetime = Some(freshness_lifetime);
         self
     }
+    /// Only use offline functionality.
+    ///
+    /// If set to `true`, when the cached path of an HTTP resource is requested,
+    /// the latest cached version is returned without checking for freshness.
+    /// But if no cached version exist, an error is returned.
+    pub fn offline(mut self, offline: bool) -> CacheBuilder {
+        self.config.offline = offline;
+        self
+    }
 
     /// Build the `Cache` object.
     pub async fn build(self) -> Result<Cache, Error> {
@@ -120,6 +132,7 @@ impl CacheBuilder {
             max_retries: self.config.max_retries,
             max_backoff: self.config.max_backoff,
             freshness_lifetime: self.config.freshness_lifetime,
+            offline: self.config.offline,
         })
     }
 
@@ -137,6 +150,7 @@ impl CacheBuilder {
             max_retries: self.config.max_retries,
             max_backoff: self.config.max_backoff,
             freshness_lifetime: self.config.freshness_lifetime,
+            offline: self.config.offline,
         })
     }
 }
@@ -157,6 +171,7 @@ pub struct Cache {
     max_retries: u32,
     max_backoff: u32,
     freshness_lifetime: Option<u64>,
+    offline: bool,
 }
 
 impl Cache {
@@ -191,37 +206,54 @@ impl Cache {
         // Find any existing cached versions of resource and check if they are still
         // fresh according to the `freshness_lifetime` setting.
         let versions = self.find_existing(resource).await; // already sorted, latest is first.
-        if !versions.is_empty() {
-            debug!("Found {} cached versions of {}", versions.len(), resource);
-            if versions[0].is_fresh() {
-                // Oh hey, the latest version is still fresh! We can clean up any
-                // older versions and return the latest.
-                info!("Latest cached version of {} is still fresh", resource);
+        if self.offline {
+            if !versions.is_empty() {
+                info!("Found existing cached version of {}", resource);
                 Cache::clean_up(&versions, Some(&versions[0].resource_path)).await;
                 return Ok(versions[0].resource_path.clone());
             } else {
-                // Existing versions are older than their freshness lifetimes, so we'll
-                // query for the ETAG of the resource and then compare that with existing
-                // versions.
-                let etag = self.try_get_etag(resource, &url).await?;
-                let path = self.resource_to_filepath(resource, &etag);
-                if path.exists() {
-                    // Oh cool! The cache is up-to-date according to the ETAG.
-                    // We'll return the up-to-date version and clean up any other
-                    // dangling ones.
-                    info!("Cached version of {} is up-to-date", resource);
-                    Cache::clean_up(&versions, Some(&path)).await;
-                    return Ok(path);
-                }
+                error!("Offline mode is enabled but no cached versions of resource exist.");
+                return Err(ErrorKind::NoCachedVersions(String::from(resource)).into());
             }
-        } else {
-            debug!("No cached versions found for {}", resource);
+        } else if !versions.is_empty() && versions[0].is_fresh(self.freshness_lifetime) {
+            // Oh hey, the latest version is still fresh! We can clean up any
+            // older versions and return the latest.
+            info!("Latest cached version of {} is still fresh", resource);
+            Cache::clean_up(&versions, Some(&versions[0].resource_path)).await;
+            return Ok(versions[0].resource_path.clone());
+        }
+
+        // No existing version or the existing versions are older than their freshness
+        // lifetimes, so we'll query for the ETAG of the resource and then compare
+        // that with any existing versions.
+        let etag = self.try_get_etag(resource, &url).await?;
+        let path = self.resource_to_filepath(resource, &etag);
+
+        // Before going further we need to obtain a lock on the file to provide
+        // parallel downloads of the same resource.
+        info!("Acquiring lock for cache of {}", resource);
+        let lock_path = format!("{}.lock", path.to_str().unwrap());
+        let filelock = FileLock::lock(&lock_path, true, true)?;
+
+        if path.exists() {
+            // Oh cool! The cache is up-to-date according to the ETAG.
+            // We'll return the up-to-date version and clean up any other
+            // dangling ones.
+            info!("Cached version of {} is up-to-date", resource);
+            filelock.unlock()?;
+            if !versions.is_empty() {
+                Cache::clean_up(&versions, Some(&path)).await;
+            }
+            return Ok(path);
         }
 
         // No up-to-date version cached, so we have to try downloading it.
-        let meta = self.try_download_resource(resource, &url).await?;
+        let meta = self
+            .try_download_resource(resource, &url, &path, &etag)
+            .await?;
         info!("New version of {} cached", resource);
         meta.to_file().await?;
+        filelock.unlock()?;
         Cache::clean_up(&versions, Some(&meta.resource_path)).await;
         Ok(meta.resource_path)
     }
@@ -272,10 +304,12 @@ impl Cache {
         &self,
         resource: &str,
         url: &reqwest::Url,
+        path: &Path,
+        etag: &Option<String>,
     ) -> Result<Meta, Error> {
         let mut retries: u32 = 0;
         loop {
-            match self.download_resource(resource, &url).await {
+            match self.download_resource(resource, &url, path, etag).await {
                 Ok(meta) => {
                     return Ok(meta);
                 }
@@ -300,7 +334,13 @@ impl Cache {
         }
     }
 
-    async fn download_resource(&self, resource: &str, url: &reqwest::Url) -> Result<Meta, Error> {
+    async fn download_resource(
+        &self,
+        resource: &str,
+        url: &reqwest::Url,
+        path: &Path,
+        etag: &Option<String>,
+    ) -> Result<Meta, Error> {
         debug!("Attempting connection to {}", url);
 
         let mut response = self
@@ -312,21 +352,11 @@ impl Cache {
 
         debug!("Opened connection to {}", url);
 
-        let mut etag: Option<String> = None;
-        if let Some(val) = response.headers().get(ETAG) {
-            if let Ok(s) = val.to_str() {
-                etag = Some(s.into());
-                debug!("Found new ETAG for {}", resource);
-            } else {
-                warn!("Error parsing ETAG for {}", resource);
-            }
-        }
-        let path = self.resource_to_filepath(resource, &etag);
-
         // First we make a temporary file and download the contents of the resource into it.
         // Otherwise if we wrote directly to the cache file and the download got
         // interrupted we could be left with a corrupted cache file.
-        let tempfile = NamedTempFile::new().context(ErrorKind::IoError(None))?;
+        let tempfile =
+            NamedTempFile::new_in(path.parent().unwrap()).context(ErrorKind::IoError(None))?;
         let mut tempfile_write_handle =
             OpenOptions::new().write(true).open(tempfile.path()).await?;
 
@@ -336,18 +366,16 @@ impl Cache {
             tempfile_write_handle.write_all(&chunk[..]).await?;
         }
 
-        debug!("Download complete for {}", url);
+        debug!("Renaming temp file to cache location for {}", url);
 
-        // Resource successfully written to the tempfile, so we can copy the tempfile
-        // over to the cache file.
-        let mut tempfile_read_handle = OpenOptions::new().read(true).open(tempfile.path()).await?;
-        let mut cache_file_write_handle = File::create(&path).await?;
+        fs::rename(tempfile.path(), &path).await?;
 
-        debug!("Copying resource temp file to cache location for {}", url);
-
-        io::copy(&mut tempfile_read_handle, &mut cache_file_write_handle).await?;
-
-        let meta = Meta::new(String::from(resource), path, etag, self.freshness_lifetime);
+        let meta = Meta::new(
+            String::from(resource),
+            path.into(),
+            etag.clone(),
+            self.freshness_lifetime,
+        );
 
         Ok(meta)
     }
@@ -504,7 +532,7 @@ mod tests {
 
         // Setup cache.
         let cache_dir = tempdir().unwrap();
-        let cache = Cache::builder()
+        let mut cache = Cache::builder()
             .root(cache_dir.path().to_owned())
             .freshness_lifetime(300)
             .build()
@@ -531,7 +559,7 @@ mod tests {
             cache.resource_to_filepath(&resource, &Some(String::from("fake-etag")))
         );
 
-        assert_eq!(mock_1_head.times_called(), 0);
+        assert_eq!(mock_1_head.times_called(), 1);
         assert_eq!(mock_1_get.times_called(), 1);
 
         // Ensure the file and meta exist.
@@ -544,19 +572,20 @@ mod tests {
 
         // When we attempt to get the resource again, the cache should still be fresh.
         let mut meta = Meta::from_cache(&path).await.unwrap();
-        assert!(meta.is_fresh());
+        assert!(meta.is_fresh(None));
         let same_path = cache.cached_path(&resource[..]).await.unwrap();
         assert_eq!(same_path, path);
         assert!(path.is_file());
         assert!(Meta::meta_path(&path).is_file());
 
         // Didn't have to call HEAD or GET again.
-        assert_eq!(mock_1_head.times_called(), 0);
+        assert_eq!(mock_1_head.times_called(), 1);
         assert_eq!(mock_1_get.times_called(), 1);
 
         // Now expire the resource to continue testing.
         meta.expires = None;
         meta.to_file().await.unwrap();
+        cache.freshness_lifetime = None;
 
         // After calling again when the resource is no longer fresh, the ETAG
         // should have been queried again with HEAD, but the resource should not have been
@@ -565,7 +594,7 @@ mod tests {
         assert_eq!(same_path, path);
         assert!(path.is_file());
         assert!(Meta::meta_path(&path).is_file());
-        assert_eq!(mock_1_head.times_called(), 1);
+        assert_eq!(mock_1_head.times_called(), 2);
         assert_eq!(mock_1_get.times_called(), 1);
 
         // Now update the resource.

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,12 @@ pub enum ErrorKind {
     )]
     ResourceNotFound(String),
 
+    #[fail(
+        display = "Offline mode is enabled but no cached versions of resouce exist ({})",
+        _0
+    )]
+    NoCachedVersions(String),
+
     #[fail(display = "Unable to parse resource URL ({})", _0)]
     InvalidUrl(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub use crate::error::{Error, ErrorKind};
 pub use crate::meta::Meta;
 
 lazy_static! {
-    static ref CACHE: Cache = { Cache::builder().build_sync().unwrap() };
+    static ref CACHE: Cache = Cache::builder().build_sync().unwrap();
 }
 
 /// Try downloading and caching a static HTTP resource. If successful, the return value

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,10 @@ struct Opt {
     #[structopt(long = "freshness-lifetime")]
     /// Set the a default freshness lifetime (in seconds) for cached resources.
     freshness_lifetime: Option<u64>,
+
+    #[structopt(long = "offline")]
+    /// Only use offline features.
+    offline: bool,
 }
 
 #[tokio::main]
@@ -87,7 +91,7 @@ async fn main() -> Result<(), ExitFailure> {
 }
 
 async fn build_cache_from_opt(opt: &Opt) -> Result<Cache, Error> {
-    let mut cache_builder = Cache::builder();
+    let mut cache_builder = Cache::builder().offline(opt.offline);
     if let Some(root) = &opt.root {
         cache_builder = cache_builder.root(root.clone());
     }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -87,9 +87,14 @@ impl Meta {
         Ok(meta)
     }
 
-    /// Check if resource is still fresh.
-    pub fn is_fresh(&self) -> bool {
-        if let Some(expiration_time) = self.expires {
+    /// Check if resource is still fresh. Passing a `Some` value for
+    /// `freshness_lifetime` will override the expiration time (if there is one)
+    /// of this resource.
+    pub fn is_fresh(&self, freshness_lifetime: Option<u64>) -> bool {
+        if let Some(lifetime) = freshness_lifetime {
+            let expiration_time = self.creation_time + (lifetime as f64);
+            expiration_time > now()
+        } else if let Some(expiration_time) = self.expires {
             expiration_time > now()
         } else {
             false


### PR DESCRIPTION
Makes more robust by renaming temp file to cache location instead of copying over. This is also faster. It always uses a file lock now to bar against downloading the same resource in parallel.

The offline mode is useful if you have already cached a resource and want to access the cached path again without making any HTTP requests.