### PR TITLE
stream response to file buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Updated the download method to stream the response into the target file.
+
 ## [v0.4.2](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.4.2) - 2020-09-11
 
 ### Fixed

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,7 +7,6 @@ use reqwest::header::ETAG;
 use std::default::Default;
 use std::env;
 use std::fs::{self, OpenOptions};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{self, Duration};
@@ -362,7 +361,7 @@ impl Cache {
     ) -> Result<Meta, Error> {
         debug!("Attempting connection to {}", url);
 
-        let response = self
+        let mut response = self
             .http_client
             .get(url.clone())
             .send()?
@@ -378,7 +377,7 @@ impl Cache {
 
         info!("Starting download of {}", url);
 
-        tempfile_write_handle.write_all(&response.bytes()?)?;
+        response.copy_to(&mut tempfile_write_handle)?;
 
         debug!("Writing meta file");
 


### PR DESCRIPTION
Hi @epwalsh ,

I was looking at the code in the context of https://github.com/guillaume-be/rust-bert/pull/74 and noticed that the current download method loads the entire response content before writing it to a file. As this crate makes most sense for large downloads, it may be better to stream the response directly to the file buffer.

Please let me know what you think