### PR TITLE
improve progress bar, add 'light' type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added a method `CacheBuilder::progress_bar` to set the progress bar type, or to disable the progess bar entirely. The options are `ProgressBar::Light` and `ProgressBar::Full`. The default when using `cached-path` as a library is `ProgressBar::Light`, while the default from the command-line is `ProgressBar::Full`. To use the "light" version from the command-line, pass the "--file-friendly-logging" flag.
+
 ## [v0.4.4](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.4.4) - 2020-09-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a method `CacheBuilder::progress_bar` to set the progress bar type, or to disable the progess bar entirely. The options are `ProgressBar::Light` and `ProgressBar::Full`. The default when using `cached-path` as a library is `ProgressBar::Light`, while the default from the command-line is `ProgressBar::Full`. To use the "light" version from the command-line, pass the "--file-friendly-logging" flag.
+- Added a method `CacheBuilder::progress_bar` to set the progress bar type, or to disable the progess bar entirely. The options are `ProgressBar::Light` and `ProgressBar::Full`. The default when using `cached-path` as a library is `ProgressBar::Light`, while the default from the command-line is `ProgressBar::Full`. You can also disable the progress bar from the command-line by passing the  "-q" / "--quietly" flag.
 
 ## [v0.4.4](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.4.4) - 2020-09-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached-path"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["epwalsh <epwalsh10@gmail.com>"]
 edition = "2018"
 keywords = ["http", "caching"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,6 +1,5 @@
 use fs2::FileExt;
 use glob::glob;
-use indicatif::{ProgressBar, ProgressStyle};
 use log::{debug, error, info, warn};
 use rand::distributions::{Distribution, Uniform};
 use reqwest::blocking::{Client, ClientBuilder};
@@ -15,7 +14,7 @@ use tempfile::NamedTempFile;
 
 use crate::archives::{extract_archive, ArchiveFormat};
 use crate::utils::hash_str;
-use crate::{meta::Meta, Error};
+use crate::{meta::Meta, Error, ProgressBar};
 
 /// Builder to facilitate creating [`Cache`](struct.Cache.html) objects.
 #[derive(Debug)]
@@ -31,6 +30,7 @@ struct Config {
     max_backoff: u32,
     freshness_lifetime: Option<u64>,
     offline: bool,
+    progress_bar: Option<ProgressBar>,
 }
 
 impl CacheBuilder {
@@ -44,6 +44,7 @@ impl CacheBuilder {
                 max_backoff: 5000,
                 freshness_lifetime: None,
                 offline: false,
+                progress_bar: Some(ProgressBar::default()),
             },
         }
     }
@@ -109,6 +110,14 @@ impl CacheBuilder {
         self
     }
 
+    /// Set the type of progress bar to use.
+    ///
+    /// The default is `Some(ProgressBar::Light)`.
+    pub fn progress_bar(mut self, progress_bar: Option<ProgressBar>) -> CacheBuilder {
+        self.config.progress_bar = progress_bar;
+        self
+    }
+
     /// Build the `Cache` object.
     pub fn build(self) -> Result<Cache, Error> {
         let dir = self.config.dir.unwrap_or_else(|| {
@@ -127,6 +136,7 @@ impl CacheBuilder {
             max_backoff: self.config.max_backoff,
             freshness_lifetime: self.config.freshness_lifetime,
             offline: self.config.offline,
+            progress_bar: self.config.progress_bar,
         })
     }
 }
@@ -186,6 +196,9 @@ pub struct Cache {
     ///
     /// If set to `true`, no HTTP calls will be made.
     offline: bool,
+    /// The verbosity level of the progress bar.
+    progress_bar: Option<ProgressBar>,
+    /// The HTTP client used to fetch remote resources.
     http_client: Client,
 }
 
@@ -498,17 +511,19 @@ impl Cache {
         // Otherwise if we wrote directly to the cache file and the download got
         // interrupted we could be left with a corrupted cache file.
         let tempfile = NamedTempFile::new_in(path.parent().unwrap())?;
-        let tempfile_write_handle = OpenOptions::new().write(true).open(tempfile.path())?;
+        let mut tempfile_write_handle = OpenOptions::new().write(true).open(tempfile.path())?;
 
         info!("Starting download of {}", url);
 
-        let spinner = ProgressBar::new_spinner();
-        spinner.set_style(
-            ProgressStyle::default_spinner()
-                .template("{spinner} {bytes} [{bytes_per_sec}, {elapsed}]"),
-        );
-        spinner.set_draw_delta(100_000);
-        response.copy_to(&mut spinner.wrap_write(tempfile_write_handle))?;
+        if let Some(progress_bar) = &self.progress_bar {
+            let mut download_wrapper =
+                progress_bar.get_download_wrapper(response.content_length(), tempfile_write_handle);
+            let bytes = response.copy_to(&mut download_wrapper)?;
+            download_wrapper.finalize(bytes);
+        } else {
+            let bytes = response.copy_to(&mut tempfile_write_handle)?;
+            info!("Downloaded {} bytes", bytes);
+        }
 
         debug!("Writing meta file");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,10 +99,12 @@ pub(crate) mod archives;
 mod cache;
 mod error;
 pub(crate) mod meta;
+mod progress_bar;
 pub(crate) mod utils;
 
 pub use crate::cache::{Cache, CacheBuilder, Options};
 pub use crate::error::Error;
+pub use crate::progress_bar::ProgressBar;
 
 /// Get the cached path to a resource.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,9 @@ struct Opt {
     /// Only use offline features.
     offline: bool,
 
-    #[structopt(long = "file-friendly-logging")]
-    /// Use a light / file-friendly progress bar for downloads.
-    file_friendly_logging: bool,
+    #[structopt(short = "-q", long = "quietly")]
+    /// Disable the progress bar for downloads.
+    quietly: bool,
 }
 
 fn main() -> Result<()> {
@@ -89,8 +89,10 @@ fn build_cache_from_opt(opt: &Opt) -> Result<Cache, Error> {
     }
     cache_builder = cache_builder.max_retries(opt.max_retries);
     cache_builder = cache_builder.max_backoff(opt.max_backoff);
-    if !opt.file_friendly_logging {
+    if !opt.quietly {
         cache_builder = cache_builder.progress_bar(Some(ProgressBar::Full));
+    } else {
+        cache_builder = cache_builder.progress_bar(None);
     }
     cache_builder.build()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
+use cached_path::{Cache, Error, Options, ProgressBar};
 use log::debug;
 use std::path::PathBuf;
 use std::time::Duration;
 use structopt::StructOpt;
-
-use cached_path::{Cache, Error, Options};
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -54,6 +53,10 @@ struct Opt {
     #[structopt(long = "offline")]
     /// Only use offline features.
     offline: bool,
+
+    #[structopt(long = "file-friendly-logging")]
+    /// Use a light / file-friendly progress bar for downloads.
+    file_friendly_logging: bool,
 }
 
 fn main() -> Result<()> {
@@ -86,5 +89,8 @@ fn build_cache_from_opt(opt: &Opt) -> Result<Cache, Error> {
     }
     cache_builder = cache_builder.max_retries(opt.max_retries);
     cache_builder = cache_builder.max_backoff(opt.max_backoff);
+    if !opt.file_friendly_logging {
+        cache_builder = cache_builder.progress_bar(Some(ProgressBar::Full));
+    }
     cache_builder.build()
 }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -2,6 +2,9 @@ use std::io::{self, Write};
 use std::time::Instant;
 
 /// Progress bar types.
+///
+/// This can be set with
+/// [`CacheBuilder::progress_bar()`](struct.CacheBuilder.html#method.progress_bar).
 #[derive(Debug, Clone)]
 pub enum ProgressBar {
     /// Progress bar with the highest verbosity.

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -1,0 +1,131 @@
+use std::io;
+
+/// Progress bar types.
+#[derive(Debug, Clone)]
+pub enum ProgressBar {
+    /// Progress bar with the highest verbosity.
+    ///
+    /// This should only be used if you're running `cached-path` from an interactive terminal.
+    Full,
+    /// Progress bar with that produces minimal output.
+    ///
+    /// This is a good option to use if your output is being captured to a file but you
+    /// still want to see a progress bar for downloads.
+    Light,
+}
+
+impl Default for ProgressBar {
+    fn default() -> Self {
+        ProgressBar::Light
+    }
+}
+
+impl ProgressBar {
+    pub(crate) fn get_download_wrapper<W: io::Write>(
+        &self,
+        content_length: Option<u64>,
+        writer: W,
+    ) -> ProgressBarDownloadWrap<W> {
+        let progress_bar = match content_length {
+            Some(length) => {
+                let progress_bar = indicatif::ProgressBar::new(length);
+                progress_bar.set_style(indicatif::ProgressStyle::default_spinner().template(
+                    "{percent}% {wide_bar:.cyan/blue} {bytes_per_sec},<{eta} [{bytes}, {elapsed}]",
+                ));
+                progress_bar
+            }
+            None => {
+                let progress_bar = indicatif::ProgressBar::new_spinner();
+                progress_bar.set_style(
+                    indicatif::ProgressStyle::default_spinner()
+                        .template("{spinner} {bytes_per_sec} [{bytes}, {elapsed}] {msg}"),
+                );
+                progress_bar
+            }
+        };
+        let update_every = match self {
+            ProgressBar::Full => {
+                // update every 1 MB.
+                1_000_000
+            }
+            ProgressBar::Light => {
+                progress_bar.set_style(
+                    indicatif::ProgressStyle::default_spinner()
+                        .template("[{bytes}, {elapsed}] Downloading...{msg}"),
+                );
+                // update every 100 MB.
+                100_000_000
+            }
+        };
+        ProgressBarDownloadWrap::new(self.clone(), progress_bar, writer, update_every)
+    }
+}
+
+pub(crate) struct ProgressBarDownloadWrap<W> {
+    level: ProgressBar,
+    bar: indicatif::ProgressBar,
+    wrap: W,
+    buffered_progress: usize,
+    update_every: usize,
+    updates: usize,
+}
+
+impl<W> ProgressBarDownloadWrap<W> {
+    pub(crate) fn new(
+        level: ProgressBar,
+        bar: indicatif::ProgressBar,
+        wrap: W,
+        update_every: usize,
+    ) -> Self {
+        Self {
+            level,
+            bar,
+            wrap,
+            buffered_progress: 0,
+            update_every,
+            updates: 0,
+        }
+    }
+
+    pub(crate) fn finalize(&self, bytes: u64) {
+        self.bar.set_position(bytes);
+        match self.level {
+            ProgressBar::Light => {
+                let msg = format!("{} ✓ Done!", ".".repeat(self.updates));
+                self.bar.set_message(&msg);
+            }
+            _ => self.bar.set_message("✓ Done!"),
+        };
+        self.bar.finish_at_current_pos();
+    }
+}
+
+impl<W: io::Write> io::Write for ProgressBarDownloadWrap<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.wrap.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.wrap.flush()
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice]) -> io::Result<usize> {
+        self.wrap.write_vectored(bufs)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.wrap.write_all(buf).map(|()| {
+            let inc = buf.len();
+            self.buffered_progress += inc;
+            if self.buffered_progress > self.update_every {
+                self.updates += 1;
+                self.bar.inc(self.buffered_progress as u64);
+                if let ProgressBar::Light = self.level {
+                    let msg = ".".repeat(self.updates);
+                    self.bar.set_message(&msg);
+                }
+                self.buffered_progress = 0;
+            }
+        })
+    }
+}

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -47,6 +47,9 @@ impl ProgressBar {
             }
         };
         progress_bar.println(format!("Downloading {}", resource));
+        // Update every 1 MBs.
+        // NOTE: If we don't set this, the updates happen WAY too frequently and it makes downloads
+        // take about twice as long.
         progress_bar.set_draw_delta(1_000_000);
         progress_bar
     }


### PR DESCRIPTION
Adds a method `CacheBuilder::progress_bar` to set the progress bar type, or to disable the progess bar entirely. The options are `ProgressBar::Light` and `ProgressBar::Full`. The default when using `cached-path` as a library is `ProgressBar::Light`, while the default from the command-line is `ProgressBar::Full`.

The full progress bar looks like this:

![image](https://user-images.githubusercontent.com/8812459/93145821-2428a600-f6a2-11ea-8fa3-a9164882649e.png)

while the light progress bar looks like this (and only updates every 5 seconds):

![image](https://user-images.githubusercontent.com/8812459/93145878-4d493680-f6a2-11ea-94cc-2ed5d6194d78.png)

@guillaume-be let me know what you think.