### PR TITLE
Fix lint errors

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -414,7 +414,7 @@ impl Cache {
             // dangling ones.
             info!("Cached version of {} is up-to-date", resource);
             filelock.unlock()?;
-            return Ok(Meta::from_cache(&path)?);
+            return Meta::from_cache(&path);
         }
 
         // No up-to-date version cached, so we have to try downloading it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::progress_bar::ProgressBar;
 /// it's more efficient to create and use a single `Cache` instead.
 pub fn cached_path(resource: &str) -> Result<PathBuf, Error> {
     let cache = Cache::builder().build()?;
-    Ok(cache.cached_path(resource)?)
+    cache.cached_path(resource)
 }
 
 /// Get the cached path to a resource using the given options.
@@ -126,7 +126,7 @@ pub fn cached_path(resource: &str) -> Result<PathBuf, Error> {
 /// it's more efficient to create and use a single `Cache` instead.
 pub fn cached_path_with_options(resource: &str, options: &Options) -> Result<PathBuf, Error> {
     let cache = Cache::builder().build()?;
-    Ok(cache.cached_path_with_options(resource, options)?)
+    cache.cached_path_with_options(resource, options)
 }
 
 #[cfg(test)]

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -189,8 +189,8 @@ impl DownloadBar for LightDownloadBar {
 
     fn finish(&self) {
         let duration = Instant::now().duration_since(self.start_time);
-        eprint!(
-            " ✓ Done! Finished in {}\n",
+        eprintln!(
+            " ✓ Done! Finished in {}",
             indicatif::HumanDuration(duration)
         );
         io::stderr().flush().ok();


### PR DESCRIPTION
I'm developing a library for sparse direct linear algebra as a way to teach myself rust, and I was thinking of using this project to fetch publicly-hosted data to test my code on. I noticed there were some CI failures recently and thought I'd see if I could fix them. This patch should fix the lint errors, one of which was from using `print` where a `println` was needed, and some others were due to unnecessary wrapping of a question marked-Result in another Result.

Thanks for writing this great package, I think it's going to save me a lot of time!