### PR TITLE
[WIP] use other headers, when ETAG is missing

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -586,19 +586,17 @@ impl Cache {
                 debug!("No ETAG for {}", url);
                 Ok(None)
             }
-        } else {
-            if let Some(last_modified) = response.headers().get(LAST_MODIFIED) {
-                if let Ok(s) = last_modified.to_str() {
-                    debug!("LAST-MODIFIED: {}", s);
-                    Ok(Some(s.into()))
-                } else {
-                    debug!("No LAST-MODIFIED for {}", url);
-                    Ok(None)
-                }
+        } else if let Some(last_modified) = response.headers().get(LAST_MODIFIED) {
+            if let Ok(s) = last_modified.to_str() {
+                debug!("LAST-MODIFIED: {}", s);
+                Ok(Some(s.into()))
             } else {
                 debug!("No LAST-MODIFIED for {}", url);
                 Ok(None)
             }
+        } else {
+            debug!("No LAST-MODIFIED for {}", url);
+            Ok(None)
         }
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,7 +3,7 @@ use glob::glob;
 use log::{debug, error, info, warn};
 use rand::distributions::{Distribution, Uniform};
 use reqwest::blocking::{Client, ClientBuilder};
-use reqwest::header::ETAG;
+use reqwest::header::{ETAG, LAST_MODIFIED};
 use std::default::Default;
 use std::env;
 use std::fs::{self, OpenOptions};
@@ -587,7 +587,18 @@ impl Cache {
                 Ok(None)
             }
         } else {
-            Ok(None)
+            if let Some(last_modified) = response.headers().get(LAST_MODIFIED) {
+                if let Ok(s) = last_modified.to_str() {
+                    debug!("LAST-MODIFIED: {}", s);
+                    Ok(Some(s.into()))
+                } else {
+                    debug!("No LAST-MODIFIED for {}", url);
+                    Ok(None)
+                }
+            } else {
+                debug!("No LAST-MODIFIED for {}", url);
+                Ok(None)
+            }
         }
     }
 


### PR DESCRIPTION
Using `last-modified` seems pretty straightforward.
I will take some time to figure out how to use `expires` and `cache-control` correctly.

The following material is intended to help me:

https://github.com/seanmonstar/reqwest/issues/368
https://github.com/zkat/make-fetch-happen
https://github.com/gregjones/httpcache/blob/master/httpcache.go
https://tools.ietf.org/html/rfc7234
https://github.com/kornelski/http-cache-semantics