### PR TITLE
feat: adds rusttls cargo feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        tls: ["default-tls", "rustls-tls"]
     steps:
     - uses: actions/checkout@v2
 
@@ -79,28 +80,28 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-targets --all-features -- -D warnings
+        args: --all-targets --features build-binary,${{ matrix.tls }} -- -D warnings
 
     - name: Build
       if: always()
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --all-features
+        args: --features build-binary,${{ matrix.tls }}
 
     - name: Run unit tests
       if: always()
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --lib --all-features
+        args: --lib --features build-binary,${{ matrix.tls }}
 
     - name: Run integration tests
       if: always()
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --test cli
+        args: --test cli --features build-binary,${{ matrix.tls }}
 
     - name: Run doc tests
       if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added feature flag `rustls-tls` to make use of `rustls-tls` over `native-tls` in `reqwest`.
+
 ## [v0.5.2](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.5.2) - 2022-03-07
 
 ## [v0.5.1](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.4.5) - 2020-03-29

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "Download and cache HTTP resources."
 
 [lib]
 name = "cached_path"
-path = "src/lib.rs" 
+path = "src/lib.rs"
 
 [[bin]]
 name = "cached-path"
@@ -23,7 +23,9 @@ required-features = ["build-binary"]
 
 [dependencies]
 fs2 = "0.4"
-reqwest = { version = "0.11.0", features = ["blocking"] }
+reqwest = { version = "0.11.0", default-features = false, features = [
+    "blocking",
+] }
 sha2 = "0.9"
 tempfile = "3.1"
 log = "0.4"
@@ -42,7 +44,10 @@ structopt = { version = "0.3", optional = true }
 color-eyre = { version = "0.5", optional = true }
 
 [features]
+default = ["default-tls"]
 build-binary = ["env_logger", "structopt", "color-eyre"]
+rustls-tls = ["reqwest/rustls-tls"]
+default-tls = ["reqwest/default-tls"]
 
 [dev-dependencies]
 httpmock = "0.5"


### PR DESCRIPTION
This adds a cargo feature to allow selecting `rustls-tls` over `native-tls` pulled from `reqwest`.

The primary use-case is to allow crates that pull in `cached-path` as a dependency to select the tls implementation they with to use.

Caveat: I cannot confirm that the changes to the gh action workflow are correct beyond running things locally.