### PR TITLE
Consolidate HTTP error variants into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Consolidated HTTP error variants into a single variant, `HttpError`, which sources directly from the underlying `reqwest::Error` for better error messages.
+
 ## [v0.5.3](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.5.3) - 2022-03-07
 
 ### Added

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -303,7 +303,7 @@ impl Cache {
             // Extract archive.
             debug!("Treating {} as archive", resource);
 
-            fs::create_dir_all(&dirpath.parent().unwrap())?;
+            fs::create_dir_all(dirpath.parent().unwrap())?;
 
             // Need to acquire a lock here to make sure we don't try to extract
             // the same archive in parallel from multiple processes.
@@ -367,7 +367,7 @@ impl Cache {
 
         // Ensure root directory exists in case it has changed or been removed.
         if let Some(subdir_path) = subdir {
-            fs::create_dir_all(&self.dir.join(subdir_path))?;
+            fs::create_dir_all(self.dir.join(subdir_path))?;
         } else {
             fs::create_dir_all(&self.dir)?;
         };
@@ -540,7 +540,7 @@ impl Cache {
 
         debug!("Renaming temp file to cache location for {}", url);
 
-        fs::rename(tempfile.path(), &path)?;
+        fs::rename(tempfile.path(), path)?;
 
         Ok(meta)
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -23,15 +23,15 @@ impl<'a> Fixture<'a> {
         }
         let contents = fs::read_to_string(&local_path).unwrap();
         let resource_get = server.mock(|when, then| {
-            when.method(GET).path(&format!("/{}", fixture_path));
+            when.method(GET).path(format!("/{}", fixture_path));
             then.status(200).header(ETAG_KEY, etag).body(&contents);
         });
         let resource_head = server.mock(|when, then| {
-            when.method(HEAD).path(&format!("/{}", fixture_path));
+            when.method(HEAD).path(format!("/{}", fixture_path));
             then.status(200).header(ETAG_KEY, etag);
         });
         Fixture {
-            url: server.url(&format!("/{}", fixture_path)),
+            url: server.url(format!("/{}", fixture_path)),
             get: resource_get,
             head: resource_head,
         }


### PR DESCRIPTION
The single variant sources directly from the underlying `reqwest::Error` for better error messages and backtraces. Should help https://github.com/guillaume-be/rust-bert/issues/306.