### PR TITLE
fix RUSTSEC-2020-0071

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,12 @@ jobs:
             task:
               name: Lint
               run: cargo clippy --all-targets --features build-binary -- -D warnings
+          
+          - os: ubuntu-latest
+            rust: stable
+            task:
+              name: Audit
+              run: cargo audit
 
           - os: ubuntu-latest
             rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Consolidated HTTP error variants into a single variant, `HttpError`, which sources directly from the underlying `reqwest::Error` for better error messages.
+- Fixed `RUSTSEC-2020-0071`
 
 ## [v0.5.3](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.5.3) - 2022-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `RUSTSEC-2020-0071`
+
 ## [v0.6.0](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.6.0) - 2022-12-19
 
 ### Changed
 
 - Consolidated HTTP error variants into a single variant, `HttpError`, which sources directly from the underlying `reqwest::Error` for better error messages.
-- Fixed `RUSTSEC-2020-0071`
+
 
 ## [v0.5.3](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.5.3) - 2022-03-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ thiserror = "1.0"
 flate2 = "1.0"
 tar = "0.4"
 zip = "0.6"
-zip-extensions = "0.6"
 indicatif = "0.16"
 env_logger = { version = "0.9", optional = true }
 structopt = { version = "0.3", optional = true }


### PR DESCRIPTION
This PR tries to fix https://rustsec.org/advisories/RUSTSEC-2020-0071 by removing `time 0.1` from dependency tree
