### PR TITLE
Improvements to archives handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ indicatif = "0.16"
 env_logger = { version = "0.10", optional = true }
 structopt = { version = "0.3", optional = true }
 color-eyre = { version = "0.6", optional = true }
+infer = "0.15.0"
 
 [features]
 default = ["default-tls"]

--- a/src/archives.rs
+++ b/src/archives.rs
@@ -1,5 +1,7 @@
 use crate::error::Error;
 use flate2::read::GzDecoder;
+use log::info;
+use std::convert::TryInto;
 use std::fs::{self, File};
 use std::path::Path;
 use tempfile::tempdir_in;

--- a/src/archives.rs
+++ b/src/archives.rs
@@ -1,7 +1,5 @@
 use crate::error::Error;
 use flate2::read::GzDecoder;
-use log::info;
-use std::convert::TryInto;
 use std::fs::{self, File};
 use std::path::Path;
 use tempfile::tempdir_in;

--- a/src/archives.rs
+++ b/src/archives.rs
@@ -13,9 +13,11 @@ pub(crate) enum ArchiveFormat {
 impl ArchiveFormat {
     /// Parse archive type from resource extension.
     pub(crate) fn parse_from_extension(resource: &str) -> Result<Self, Error> {
-        if resource.ends_with(".tar.gz") {
+        let ext = infer::get_from_path(resource).unwrap().unwrap().extension();
+        // Here we assume that gz contain a tar inside it.
+        if ext.ends_with("gz") {
             Ok(Self::TarGz)
-        } else if resource.ends_with(".zip") {
+        } else if ext.ends_with("zip") {
             Ok(Self::Zip)
         } else {
             Err(Error::ExtractionError("unsupported archive format".into()))
@@ -34,13 +36,13 @@ pub(crate) fn extract_archive<P: AsRef<Path>>(
 
     match format {
         ArchiveFormat::TarGz => {
-            let tar_gz = File::open(path)?;
+            let tar_gz = File::open(&path)?;
             let tar = GzDecoder::new(tar_gz);
             let mut archive = tar::Archive::new(tar);
             archive.unpack(&temp_target)?;
         }
         ArchiveFormat::Zip => {
-            let file = File::open(path)?;
+            let file = File::open(&path)?;
             let mut archive =
                 zip::ZipArchive::new(file).map_err(|e| Error::ExtractionError(e.to_string()))?;
             archive
@@ -49,6 +51,7 @@ pub(crate) fn extract_archive<P: AsRef<Path>>(
         }
     };
 
+    fs::remove_file(&path)?;
     // Now rename the temp directory to the final target directory.
     fs::rename(temp_target, target)?;
 

--- a/src/archives.rs
+++ b/src/archives.rs
@@ -12,12 +12,12 @@ pub(crate) enum ArchiveFormat {
 
 impl ArchiveFormat {
     /// Parse archive type from resource extension.
-    pub(crate) fn parse_from_extension(resource: &str) -> Result<Self, Error> {
-        let ext = infer::get_from_path(resource).unwrap().unwrap().extension();
+    pub(crate) fn parse_from_path<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let ext = infer::get_from_path(path).unwrap().unwrap().extension();
         // Here we assume that gz contain a tar inside it.
-        if ext.ends_with("gz") {
+        if ext == "gz" {
             Ok(Self::TarGz)
-        } else if ext.ends_with("zip") {
+        } else if ext == "zip" {
             Ok(Self::Zip)
         } else {
             Err(Error::ExtractionError("unsupported archive format".into()))

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -292,7 +292,6 @@ impl Cache {
             }
         } else {
             // This is a remote resource, so fetch it to the cache.
-            debug!("Getting remote file GBRLS debug {}", resource);
             let meta = self.fetch_remote_resource(resource, options.subdir.as_deref())?;
 
             // Check if we need to extract.
@@ -326,12 +325,10 @@ impl Cache {
             } else {
                 dirpath
             };
-
             if !dirpath.is_dir() {
                 info!("Extracting {} to {:?}", resource, dirpath);
                 let format = ArchiveFormat::parse_from_extension(cached_path.to_str().unwrap())?;
                 extract_archive(&cached_path, &dirpath, &format)?;
-                info!("Done extracting (deleteme) {} to {:?}", resource, dirpath);
             }
 
             filelock.unlock()?;
@@ -669,7 +666,7 @@ mod tests {
             .build()
             .unwrap();
 
-            let resource = "http://localhost:5000/foo.txt";
+        let resource = "http://localhost:5000/foo.txt";
         assert_eq!(
             cache
                 .resource_to_filepath(resource, &None, None, None)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -292,6 +292,7 @@ impl Cache {
             }
         } else {
             // This is a remote resource, so fetch it to the cache.
+            debug!("Getting remote file GBRLS debug {}", resource);
             let meta = self.fetch_remote_resource(resource, options.subdir.as_deref())?;
 
             // Check if we need to extract.
@@ -325,10 +326,12 @@ impl Cache {
             } else {
                 dirpath
             };
+
             if !dirpath.is_dir() {
                 info!("Extracting {} to {:?}", resource, dirpath);
                 let format = ArchiveFormat::parse_from_extension(cached_path.to_str().unwrap())?;
                 extract_archive(&cached_path, &dirpath, &format)?;
+                info!("Done extracting (deleteme) {} to {:?}", resource, dirpath);
             }
 
             filelock.unlock()?;
@@ -666,7 +669,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let resource = "http://localhost:5000/foo.txt";
+            let resource = "http://localhost:5000/foo.txt";
         assert_eq!(
             cache
                 .resource_to_filepath(resource, &None, None, None)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -332,7 +332,7 @@ impl Cache {
 
             if !dirpath.is_dir() {
                 info!("Extracting {} to {:?}", resource, dirpath);
-                let format = ArchiveFormat::parse_from_extension(cached_path.to_str().unwrap())?;
+                let format = ArchiveFormat::parse_from_path(&cached_path)?;
                 extract_archive(&cached_path, &dirpath, &format)?;
             }
 
@@ -448,7 +448,7 @@ impl Cache {
     fn find_existing(&self, resource: &str, subdir: Option<&str>) -> Vec<Meta> {
         let mut existing_meta: Vec<Meta> = vec![];
         let glob_string = format!(
-            "{}.*.meta",
+            "{}*.meta",
             self.resource_to_filepath(resource, &None, subdir, None)
                 .to_str()
                 .unwrap(),

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -20,6 +20,8 @@ pub(crate) struct Meta {
     pub(crate) expires: Option<f64>,
     /// Time this version of the resource was cached.
     pub(crate) creation_time: f64,
+    /// Time of the last time the resource was accessed, default to creation_time.
+    pub(crate) last_accessed: f64,
 }
 
 impl Meta {
@@ -35,6 +37,7 @@ impl Meta {
             expires = Some(creation_time + (lifetime as f64));
         }
         let meta_path = Meta::meta_path(&resource_path);
+        let last_accessed = creation_time;
         Meta {
             resource,
             resource_path,
@@ -42,6 +45,7 @@ impl Meta {
             etag,
             expires,
             creation_time,
+            last_accessed,
         }
     }
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -58,14 +58,13 @@ impl Meta {
     }
 
     pub(crate) fn get_extraction_path(&self) -> PathBuf {
-        let dirname = format!(
-            "{}-extracted",
-            self.resource_path.file_name().unwrap().to_str().unwrap()
-        );
-
         if let Some(extraction_path) = &self.extraction_path {
             self.resource_path.parent().unwrap().join(extraction_path)
         } else {
+            let dirname = format!(
+                "{}-extracted",
+                self.resource_path.file_name().unwrap().to_str().unwrap()
+            );
             self.resource_path.parent().unwrap().join(dirname)
         }
     }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -14,6 +14,8 @@ pub(crate) struct Meta {
     pub(crate) resource_path: PathBuf,
     /// Path to the serialized meta.
     pub(crate) meta_path: PathBuf,
+    /// Path to the directory that the resource is extracted.
+    pub(crate) extraction_path: Option<PathBuf>,
     /// The ETAG of the resource from the time it was cached, if there was one.
     pub(crate) etag: Option<String>,
     /// Time that the freshness of this cached resource will expire.
@@ -28,6 +30,7 @@ impl Meta {
         resource_path: PathBuf,
         etag: Option<String>,
         freshness_lifetime: Option<u64>,
+        extraction_path: Option<PathBuf>,
     ) -> Meta {
         let mut expires: Option<f64> = None;
         let creation_time = now();
@@ -42,6 +45,7 @@ impl Meta {
             etag,
             expires,
             creation_time,
+            extraction_path,
         }
     }
 
@@ -58,7 +62,12 @@ impl Meta {
             "{}-extracted",
             self.resource_path.file_name().unwrap().to_str().unwrap()
         );
-        self.resource_path.parent().unwrap().join(dirname)
+
+        if let Some(extraction_path) = &self.extraction_path {
+            self.resource_path.parent().unwrap().join(extraction_path)
+        } else {
+            self.resource_path.parent().unwrap().join(dirname)
+        }
     }
 
     pub(crate) fn to_file(&self) -> Result<(), Error> {

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -20,8 +20,6 @@ pub(crate) struct Meta {
     pub(crate) expires: Option<f64>,
     /// Time this version of the resource was cached.
     pub(crate) creation_time: f64,
-    /// Time of the last time the resource was accessed, default to creation_time.
-    pub(crate) last_accessed: f64,
 }
 
 impl Meta {
@@ -37,7 +35,6 @@ impl Meta {
             expires = Some(creation_time + (lifetime as f64));
         }
         let meta_path = Meta::meta_path(&resource_path);
-        let last_accessed = creation_time;
         Meta {
             resource,
             resource_path,
@@ -45,7 +42,6 @@ impl Meta {
             etag,
             expires,
             creation_time,
-            last_accessed,
         }
     }
 


### PR DESCRIPTION
- Added infer as a dependency so the inference of the archive type (zip, gzip) doesn't rely on the file extension.
- Added option to extract the archive to a specific directory.
- The raw archive is deleted after it's extracted. (This may cause problems, in my testings the archive are downloaded again if they're deleted)