### PR TITLE
refactor crate to use async/tokio over blocking calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ doc = false
 required-features = ["build-binary"]
 
 [dependencies]
-fs2 = "0.4"
-reqwest = { version = "0.11.0", default-features = false, features = [
-    "blocking",
-] }
+tokio = { version = "1", features = ["fs", "io-util"] }
+futures = "0.3"
+fs4 = { version = "0.7", features = ["tokio"] }
+reqwest = { version = "0.11.0", default-features = false, features = ["stream"]}
 sha2 = "0.10"
 tempfile = "3.1"
 log = "0.4"
@@ -44,7 +44,7 @@ color-eyre = { version = "0.6", optional = true }
 
 [features]
 default = ["default-tls"]
-build-binary = ["env_logger", "structopt", "color-eyre"]
+build-binary = ["env_logger", "structopt", "color-eyre", "tokio/macros", "tokio/rt"]
 rustls-tls = ["reqwest/rustls-tls"]
 default-tls = ["reqwest/default-tls"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,9 +109,9 @@ pub use crate::progress_bar::ProgressBar;
 /// with a temporary [`Cache`](crate::cache::Cache) object.
 /// Therefore if you're going to be calling this function multiple times,
 /// it's more efficient to create and use a single `Cache` instead.
-pub fn cached_path(resource: &str) -> Result<PathBuf, Error> {
+pub async fn cached_path(resource: &str) -> Result<PathBuf, Error> {
     let cache = Cache::builder().build()?;
-    cache.cached_path(resource)
+    cache.cached_path(resource).await
 }
 
 /// Get the cached path to a resource using the given options.
@@ -121,9 +121,9 @@ pub fn cached_path(resource: &str) -> Result<PathBuf, Error> {
 /// with a temporary [`Cache`](crate::cache::Cache) object.
 /// Therefore if you're going to be calling this function multiple times,
 /// it's more efficient to create and use a single `Cache` instead.
-pub fn cached_path_with_options(resource: &str, options: &Options) -> Result<PathBuf, Error> {
+pub async fn cached_path_with_options(resource: &str, options: &Options) -> Result<PathBuf, Error> {
     let cache = Cache::builder().build()?;
-    cache.cached_path_with_options(resource, options)
+    cache.cached_path_with_options(resource, options).await
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,8 @@ struct Opt {
     quietly: bool,
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     color_eyre::install()?;
     env_logger::init();
     let opt = Opt::from_args();
@@ -68,7 +69,9 @@ fn main() -> Result<()> {
 
     let cache = build_cache_from_opt(&opt)?;
     let options = Options::new(opt.subdir.as_deref(), opt.extract);
-    let path = cache.cached_path_with_options(&opt.resource, &options)?;
+    let path = cache
+        .cached_path_with_options(&opt.resource, &options)
+        .await?;
     println!("{}", path.to_string_lossy());
 
     Ok(())


### PR DESCRIPTION
Thanks a lot for this crate. The current use of `reqwest::blocking` panics when used in an async environment. One workaround would be to use `spawn_blocking` but I thought this might create issues with large downloads.

This commit keeps all functionality as is but uses the Tokio runtime to make it work in an async environment. This means in turn that the current crate does not work in a sync environment. Omitted are any updates regarding documentation.

```
#[tokio::main]
async fn main() {
    let cache_dir = dirs::cache_dir().unwrap();
    let remote = "https://...";
    let local_path = "my/download/path";

    let cache = Cache::builder()
        .dir(cache_dir)
        .progress_bar(None)
        .build()
        .unwrap();

    let path = self
        .cache
        .cached_path_with_options(&remote, &Options::default().subdir(&local_path))
        .await
        .unwrap();

    println!("{:?}", path);
}
```

I don't know if you are interested at all in making rust-cached-path work on async. If you are, maybe I can improve the commit and make the crate dual use (sync and async). Not sure though what the best approach would be. In any case I wanted to share this commit with you.