### PR TITLE
[FIX] offline mode cannot find cached path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed some issues with old dependencies.
+- Fixed a bug causing cache misses.
 
 ## [v0.6.1](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.6.1) - 2023-02-24
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -431,7 +431,7 @@ impl Cache {
     fn find_existing(&self, resource: &str, subdir: Option<&str>) -> Vec<Meta> {
         let mut existing_meta: Vec<Meta> = vec![];
         let glob_string = format!(
-            "{}.*.meta",
+            "{}*.meta",
             self.resource_to_filepath(resource, &None, subdir, None)
                 .to_str()
                 .unwrap(),


### PR DESCRIPTION

The previous offline mode cannot find cached path since there is a typo in the regular expression.

Specifically:

In the `src/cache.rs`, the `fn find_string` is using `{}.*.meta"`, which should be changed to `"{}*.meta" 

This PR fixed the issue
