### PR TITLE
update reqwest to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["build-binary"]
 
 [dependencies]
 fs2 = "0.4"
-reqwest = { version = "0.11.0", default-features = false, features = [
+reqwest = { version = "0.12.0", default-features = false, features = [
     "blocking",
 ] }
 sha2 = "0.10"


### PR DESCRIPTION
This updates `reqwest` to `0.12.0` which was first released over a year ago.
The current highest semver-compatible release is 0.12.23 from a couple of days ago.

As `cached_path` exposes reqwest in `Error::HttpError` I suppose this needs a new minor (0.9.0) release as it is considered a breaking change.