### PR TITLE
feat: add a `progress-bar` feature to disable `indicatif` dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,9 @@ jobs:
           - name: Test (rustls-tls)
             run: cargo test --features build-binary,lzma,rustls-tls
 
+          - name: Test (default features)
+            run: cargo test
+
         include:
           - os: ubuntu-latest
             rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added a `progress-bar` feature to enable the `indicatif` dependency.
+
 ## [v0.9.0](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.9.0) - 2025-08-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
 - Added a `progress-bar` feature to enable the `indicatif` dependency.
 
 ## [v0.9.0](https://github.com/epwalsh/rust-cached-path/releases/tag/v0.9.0) - 2025-08-25

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0"
 flate2 = "1.0"
 tar = "0.4"
 zip = "0.6"
-indicatif = "0.17.11"
+indicatif = { version = "0.17.11", optional = true }
 env_logger = { version = "0.10", optional = true }
 structopt = { version = "0.3", optional = true }
 color-eyre = { version = "0.6", optional = true }
@@ -46,10 +46,11 @@ lzma-rs = { version = "0.3", optional = true }
 
 [features]
 default = ["default-tls"]
-build-binary = ["env_logger", "structopt", "color-eyre"]
+build-binary = ["env_logger", "structopt", "color-eyre", "progress-bar"]
 rustls-tls = ["reqwest/rustls-tls"]
 default-tls = ["reqwest/default-tls"]
 lzma = ["lzma-rs"]
+progress-bar = ["indicatif"]
 
 [dev-dependencies]
 httpmock = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,11 +96,13 @@ pub(crate) mod archives;
 mod cache;
 mod error;
 pub(crate) mod meta;
+#[cfg(feature = "progress-bar")]
 mod progress_bar;
 pub(crate) mod utils;
 
 pub use crate::cache::{Cache, CacheBuilder, Options};
 pub use crate::error::Error;
+#[cfg(feature = "progress-bar")]
 pub use crate::progress_bar::ProgressBar;
 
 /// Get the cached path to a resource.

--- a/src/test.rs
+++ b/src/test.rs
@@ -46,13 +46,30 @@ impl Drop for Fixture<'_> {
     }
 }
 
+trait BuilderExt {
+    fn disable_progress_bar(self) -> Self;
+}
+
+impl BuilderExt for crate::cache::CacheBuilder {
+    fn disable_progress_bar(self) -> Self {
+        #[cfg(feature = "progress-bar")]
+        {
+            self.progress_bar(None)
+        }
+        #[cfg(not(feature = "progress-bar"))]
+        {
+            self
+        }
+    }
+}
+
 #[test]
 fn test_get_cached_path_local_file() {
     // Setup cache.
     let cache_dir = tempdir().unwrap();
     let cache = Cache::builder()
         .dir(cache_dir.path().to_owned())
-        .progress_bar(None)
+        .disable_progress_bar()
         .build()
         .unwrap();
 
@@ -66,7 +83,7 @@ fn test_get_cached_path_non_existant_local_file_fails() {
     let cache_dir = tempdir().unwrap();
     let cache = Cache::builder()
         .dir(cache_dir.path().to_owned())
-        .progress_bar(None)
+        .disable_progress_bar()
         .build()
         .unwrap();
 
@@ -84,7 +101,7 @@ fn test_cached_path_remote_file() {
     let cache_dir = tempdir().unwrap();
     let cache = Cache::builder()
         .dir(cache_dir.path().to_owned())
-        .progress_bar(None)
+        .disable_progress_bar()
         .freshness_lifetime(300)
         .build()
         .unwrap();
@@ -127,7 +144,7 @@ fn test_cached_path_remote_file() {
     // Create a new cache without a freshness lifetime.
     let cache = Cache::builder()
         .dir(cache_dir.path().to_owned())
-        .progress_bar(None)
+        .disable_progress_bar()
         .build()
         .unwrap();
 
@@ -173,7 +190,7 @@ fn test_cached_path_remote_file_in_subdir() {
     let cache_dir = tempdir().unwrap();
     let cache = Cache::builder()
         .dir(cache_dir.path().to_owned())
-        .progress_bar(None)
+        .disable_progress_bar()
         .build()
         .unwrap();
 
@@ -197,7 +214,7 @@ fn assert_extract_archive(filename: &str) {
     let cache_dir = tempdir().unwrap();
     let cache = Cache::builder()
         .dir(cache_dir.path().to_owned())
-        .progress_bar(None)
+        .disable_progress_bar()
         .build()
         .unwrap();
 
@@ -245,7 +262,7 @@ fn test_extract_in_subdir() {
     let cache_dir = tempdir().unwrap();
     let cache = Cache::builder()
         .dir(cache_dir.path().to_owned())
-        .progress_bar(None)
+        .disable_progress_bar()
         .build()
         .unwrap();
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::process::Command; // Run programs
 use tempfile::tempdir;
 
+#[cfg(feature = "build-binary")]
 #[test]
 fn file_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::new(cargo::cargo_bin("cached-path"));
@@ -22,6 +23,7 @@ fn file_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[cfg(feature = "build-binary")]
 #[test]
 fn test_remote_file() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::new(cargo::cargo_bin("cached-path"));
@@ -61,6 +63,7 @@ fn test_remote_file() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[cfg(feature = "build-binary")]
 #[test]
 fn test_extract_remote_file() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::new(cargo::cargo_bin("cached-path"));
@@ -86,6 +89,7 @@ fn test_extract_remote_file() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[cfg(feature = "build-binary")]
 #[test]
 fn test_extract_local_file() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::new(cargo::cargo_bin("cached-path"));


### PR DESCRIPTION
For usage within library, the extra `indicatif` dependency is not desirable. This adds a Cargo feature to entirely disable the progress bar feature (and thus, the `indicatif` dependency).