### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tempfile = "3.1"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rand = "0.8"
+rand = "0.10"
 glob = "0.3"
 thiserror = "1.0"
 flate2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,6 @@ lzma = ["lzma-rs"]
 progress-bar = ["indicatif"]
 
 [dev-dependencies]
-httpmock = "0.7"
-assert_cmd = "1.0"
-predicates = "2.1"
+httpmock = "0.8"
+assert_cmd = "2.0"
+predicates = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.10"
 glob = "0.3"
-thiserror = "1.0"
+thiserror = "2.0"
 flate2 = "1.0"
 tar = "0.4"
-zip = "0.6"
-indicatif = { version = "0.17.11", optional = true }
-env_logger = { version = "0.10", optional = true }
+zip = "8.0"
+indicatif = { version = "0.18.0", optional = true }
+env_logger = { version = "0.11", optional = true }
 structopt = { version = "0.3", optional = true }
 color-eyre = { version = "0.6", optional = true }
 infer = "0.19.0"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,7 @@
 use fs2::FileExt;
 use glob::glob;
 use log::{debug, error, info, warn};
-use rand::distributions::{Distribution, Uniform};
+use rand::RngExt;
 use reqwest::blocking::{Client, ClientBuilder};
 use reqwest::header::ETAG;
 use std::default::Default;
@@ -484,10 +484,9 @@ impl Cache {
     }
 
     fn get_retry_delay(&self, retries: u32) -> u32 {
-        let between = Uniform::from(0..1000);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rngs::ThreadRng::default();
         std::cmp::min(
-            2u32.pow(retries - 1) * 1000 + between.sample(&mut rng),
+            2u32.pow(retries - 1) * 1000 + rng.random_range(0..1000),
             self.max_backoff,
         )
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -113,8 +113,8 @@ fn test_cached_path_remote_file() {
     // Get the cached path.
     let path = cache.cached_path(resource).unwrap();
 
-    assert_eq!(fixture.head.hits(), 1);
-    assert_eq!(fixture.get.hits(), 1);
+    assert_eq!(fixture.head.calls(), 1);
+    assert_eq!(fixture.get.calls(), 1);
 
     // Ensure the file and meta exist.
     assert!(path.is_file());
@@ -134,8 +134,8 @@ fn test_cached_path_remote_file() {
     assert!(Meta::meta_path(&path).is_file());
 
     // Didn't have to call HEAD or GET again.
-    assert_eq!(fixture.head.hits(), 1);
-    assert_eq!(fixture.get.hits(), 1);
+    assert_eq!(fixture.head.calls(), 1);
+    assert_eq!(fixture.get.calls(), 1);
 
     // Now expire the resource to continue testing.
     meta.expires = None;
@@ -155,8 +155,8 @@ fn test_cached_path_remote_file() {
     assert_eq!(same_path, path);
     assert!(path.is_file());
     assert!(Meta::meta_path(&path).is_file());
-    assert_eq!(fixture.head.hits(), 2);
-    assert_eq!(fixture.get.hits(), 1);
+    assert_eq!(fixture.head.calls(), 2);
+    assert_eq!(fixture.get.calls(), 1);
 
     // Now update the resource.
     drop(fixture);
@@ -165,8 +165,8 @@ fn test_cached_path_remote_file() {
     // Get the new cached path.
     let new_path = cache.cached_path(&fixture.url).unwrap();
 
-    assert_eq!(fixture.head.hits(), 1);
-    assert_eq!(fixture.get.hits(), 1);
+    assert_eq!(fixture.head.calls(), 1);
+    assert_eq!(fixture.get.calls(), 1);
 
     // This should be different from the old path.
     assert_ne!(path, new_path);
@@ -202,8 +202,8 @@ fn test_cached_path_remote_file_in_subdir() {
         .cached_path_with_options(&fixture.url, &Options::default().subdir("target"))
         .unwrap();
 
-    assert_eq!(fixture.head.hits(), 1);
-    assert_eq!(fixture.get.hits(), 1);
+    assert_eq!(fixture.head.calls(), 1);
+    assert_eq!(fixture.get.calls(), 1);
 
     // Ensure the file and meta exist.
     assert!(path.is_file());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,7 +10,7 @@ use tempfile::tempdir;
 #[cfg(feature = "build-binary")]
 #[test]
 fn file_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::new(cargo::cargo_bin("cached-path"));
+    let mut cmd = Command::new(cargo::cargo_bin!("cached-path"));
     let cache_dir = tempdir().unwrap().path().to_owned();
 
     cmd.arg("--dir")
@@ -26,7 +26,7 @@ fn file_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "build-binary")]
 #[test]
 fn test_remote_file() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::new(cargo::cargo_bin("cached-path"));
+    let mut cmd = Command::new(cargo::cargo_bin!("cached-path"));
     let cache_dir = tempdir().unwrap().path().to_owned();
 
     cmd.arg("--dir")
@@ -66,7 +66,7 @@ fn test_remote_file() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "build-binary")]
 #[test]
 fn test_extract_remote_file() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::new(cargo::cargo_bin("cached-path"));
+    let mut cmd = Command::new(cargo::cargo_bin!("cached-path"));
     let cache_dir = tempdir().unwrap().path().to_owned();
 
     cmd.arg("--dir")
@@ -92,7 +92,7 @@ fn test_extract_remote_file() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "build-binary")]
 #[test]
 fn test_extract_local_file() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::new(cargo::cargo_bin("cached-path"));
+    let mut cmd = Command::new(cargo::cargo_bin!("cached-path"));
     let cache_dir = tempdir().unwrap().path().to_owned();
 
     cmd.arg("--dir")


### PR DESCRIPTION
This updates:
* rand from 0.8 to 0.10
* thiserror from 1.0 to 2.0
* zip from 0.6 to 8.0 (which will update bzip2 from 0.4.4 to 0.6)
* indicatif from 0.17 to 0.18
* env_logger from 0.10 to 0.11

Additionally dev-dependencies:
* httpmock from 0.7 to 0.8
* assert_cmd from 1.0 to 2.0
* predicates from 2.1 to 3.0


This omits reqwest 0.13 due to changes in rustls provider features. See https://github.com/seanmonstar/reqwest/issues/2924. I am currently not sure what the best way would be to let users of this crate efficiently select the used crypto lib using features.
